### PR TITLE
NO-JIRA fix typos

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/journal/ActiveMQJournalBundle.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/journal/ActiveMQJournalBundle.java
@@ -39,7 +39,7 @@ public interface ActiveMQJournalBundle {
    @Message(id = 149001, value = "Journal data belong to a different version")
    ActiveMQIOErrorException journalDifferentVersion();
 
-   @Message(id = 149002, value = "Journal files version mismatch. You should export the data from the previous version and import it as explained on the user''s manual")
+   @Message(id = 149002, value = "Journal files version mismatch. You should export the data from the previous version and import it as explained on the user's manual")
    ActiveMQIOErrorException journalFileMisMatch();
 
    @Message(id = 149003, value = "File not opened")

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
@@ -35,7 +35,7 @@ import org.apache.activemq.artemis.core.transaction.Transaction;
 public class WildcardAddressManager extends SimpleAddressManager {
 
    /**
-    * These are all the addresses, we use this so we can link back from the actual address to its linked wilcard addresses
+    * These are all the addresses, we use this so we can link back from the actual address to its linked wildcard addresses
     * or vice versa
     */
    private final Map<SimpleString, Address> addresses = new ConcurrentHashMap<>();


### PR DESCRIPTION
Hello. The typo in comment is obvious. I think the double-apostrophe is a typo too, because I saw this in the logs from running tests

    [Thread-0 (org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnector)] 12:10:09,591 WARN  [org.apache.activemq.artemis.core.server] AMQ222086: error handling packet PACKET(ReplicationStartSyncMessage)[type=120, channelID=2, packetObject=ReplicationStartSyncMessage, synchronizationIsFinished=true, dataType=null, nodeID=1f46e0eb-43c0-11e7-86e0-fa163e5a2b31, ids=null, allowsAutoFailBack=false] for replication: ActiveMQIOErrorException[errorType=IO_ERROR message=AMQ149002: Journal files version mismatch. You should export the data from the previous version and import it as explained on the user''s manual]

But maybe the tests are printing the errors in some non-standard ways, so it is actually ok....